### PR TITLE
update cloud mode actions to default to v2.0

### DIFF
--- a/packages/destination-actions/src/destinations/fullstory/index.ts
+++ b/packages/destination-actions/src/destinations/fullstory/index.ts
@@ -15,15 +15,15 @@ const destination: DestinationDefinition<Settings> = {
     {
       name: 'Track Event',
       subscribe: 'type = "track"',
-      partnerAction: 'trackEvent',
-      mapping: defaultValues(trackEvent.fields),
+      partnerAction: 'trackEventV2',
+      mapping: defaultValues(trackEventV2.fields),
       type: 'automatic'
     },
     {
       name: 'Identify User',
       subscribe: 'type = "identify"',
-      partnerAction: 'identifyUser',
-      mapping: defaultValues(identifyUser.fields),
+      partnerAction: 'identifyUserV2',
+      mapping: defaultValues(identifyUserV2.fields),
       type: 'automatic'
     }
   ],


### PR DESCRIPTION
<!-- Hello and thank you for contributing to Segment action-destinations! -->

<!-- Before opening your pull request, make sure you have added and ran unit
     tests and tested your change locally. Refer to our testing
     documentation for more information: https://github.com/segmentio/action-destinations/blob/main/docs/testing.md -->

<!-- If you have questions or issues please open a new issue or create a new discussion
     post in Github. -->

Updating the default actions for Cloud mode to the v2 versions. I accidentally opened a PR against the main repo and then closed it which might be why there are tests running and failing, but hopefully once we open the big PR against the main repo they will pass. Tests pass locally.

## Testing

_Include any additional information about the testing you have completed to
ensure your changes behave as expected. For a speedy review, please check
any of the tasks you completed below during your testing._

- [x] Added [unit tests](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing) for new functionality
- [x] Tested end-to-end using the [local server](https://github.com/segmentio/action-destinations/blob/main/docs/testing.md#local-end-to-end-testing)
- [x] [Segmenters] Tested in the staging environment
